### PR TITLE
Update cath to load the home page

### DIFF
--- a/src/Dominion.js
+++ b/src/Dominion.js
@@ -178,7 +178,7 @@ const loadWeb3 = async () => {
   } catch (error) {
     alert('Please connect your metamask wallet!')
     console.log(error)
-    return false
+    return true
   }
 }
 


### PR DESCRIPTION
If **return false**, the first-time visitor gets a white screen and an alert that says _"connect wallet"_. The designed page with the connect wallet button and a preview of the DAO will **not be displayed**. After **returning true**, the alert will also be displayed if the wallet is not connected, but the start page will be **displayed**.